### PR TITLE
:lollipop: Update default opts for selfsigned `keyUsage` extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 
 ## v-next
-* 
+* :lollipop: Update default opts for selfsigned `keyUsage` extension
 
 ## v1.3.2
 * :house: Update dependencies

--- a/__tests__/certificate.test.js
+++ b/__tests__/certificate.test.js
@@ -109,9 +109,12 @@ describe('server', () => {
             },
             {
               critical: true,
+              dataEncipherment: true,
+              digitalSignature: true,
               keyCertSign: true,
               keyEncipherment: true,
               name: 'keyUsage',
+              nonRepudiation: true,
             },
             {
               clientAuth: true,

--- a/src/certificate.js
+++ b/src/certificate.js
@@ -57,9 +57,12 @@ service.generate = (vhostName, selfsignedConf) => {
       },
       {
         critical: true,
+        dataEncipherment: true,
+        digitalSignature: true,
         keyCertSign: true,
         keyEncipherment: true,
         name: 'keyUsage',
+        nonRepudiation: true,
       },
       {
         clientAuth: true,


### PR DESCRIPTION
:lollipop: Update default opts for selfsigned `keyUsage` extension